### PR TITLE
Flake8: exclude 'venv' folder

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 120
-exclude = .venv,dist,docs,build,*.egg,.git,__pycache__
+exclude = .venv,dist,docs,build,*.egg,.git,__pycache__,venv
 count = true
 show-source = true
 statistics = true


### PR DESCRIPTION
Additional folder to exclude from flake8 run. 